### PR TITLE
Add crop_to_bbox function to restore nnUNet compatibility

### DIFF
--- a/acvl_utils/cropping_and_padding/bounding_boxes.py
+++ b/acvl_utils/cropping_and_padding/bounding_boxes.py
@@ -44,11 +44,18 @@ def bounding_box_to_slice(bounding_box: List[List[int]]):
     return tuple([slice(*i) for i in bounding_box])
 
 
+def crop_to_bbox(array: np.ndarray, bounding_box: List[List[int]]):
+    assert len(bounding_box) == len(array.shape), f"Dimensionality of bbox and array do not match. bbox has length " \
+                                          f"{len(bounding_box)} while array has dimension {len(array.shape)}"
+    slicer = bounding_box_to_slice(bounding_box)
+    return array[slicer]
+
+
 def get_bbox_from_mask(mask: np.ndarray) -> List[List[int]]:
     """
     this implementation uses less ram than the np.where one and is faster as well IF we expect the bounding box to
     be close to the image size. If it's not it's likely slower!
-    
+
     bbox is returned so that you can just do slice(minzidx, maxzidx) to retrieve the object of interest with nothing cut off
 
     :param mask:


### PR DESCRIPTION
The crop_to_bbox function was removed recently from acvl_utils.cropping_and_padding.bounding_boxes, causing an import error when using nnUNetPredictor in nnUNet (e.g., with from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor after a fresh installation via pip install nnunetv2).

This pull request restores the crop_to_bbox function to address this compatibility issue, allowing nnUNet users to run inference without import errors.

